### PR TITLE
fix(client): 修复获取股票列表时未添加前缀的问题

### DIFF
--- a/client.go
+++ b/client.go
@@ -291,7 +291,7 @@ func (this *Client) GetETFAll() ([]string, error) {
 			return nil, err
 		}
 		for _, v := range resp.List {
-			if protocol.IsETF(v.Code) {
+			if protocol.IsETF(protocol.AddPrefix(v.Code)) {
 				ls = append(ls, v.Code)
 			}
 		}

--- a/client.go
+++ b/client.go
@@ -274,7 +274,7 @@ func (this *Client) GetStockAll() ([]string, error) {
 			return nil, err
 		}
 		for _, v := range resp.List {
-			if protocol.IsStock(v.Code) {
+			if protocol.IsStock(protocol.AddPrefix(v.Code)) {
 				ls = append(ls, v.Code)
 			}
 		}


### PR DESCRIPTION
在 GetStockAll 方法中，调用 protocol.IsStock 判断时，
需要先对股票代码添加前缀，以确保正确识别股票类型。