### PR TITLE
新增 spblock.dat 解析: 中证2000/1000/500 等大型指数成分

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 | 财务信息           | ✅ 已完成 | `GetFinanceInfo`                               |
 | F10 公司资料       | ✅ 已完成 | `GetCompanyCategory` `GetCompanyContent`        |
 | 板块成分(地域/概念/指数) | ✅ 已完成 | `GetBlockData` `GetBlockDataWithIndex`          |
+| 大型指数成分(中证2000等) | ✅ 已完成 | `GetSpBlock`                                    |
 | 行业归属(通达信/申万)   | ✅ 已完成 | `GetTdxHy`                                      |
 | 报表/配置文件下载      | ✅ 已完成 | `GetReportFile` `GetZHBFiles`                   |
 | 板块指数代码(id)映射   | ✅ 已完成 | `GetTdxZs` `GetTdxBk`                           |
@@ -90,6 +91,27 @@ for _, b := range blocks {
 plain, _ := c.GetBlockData(protocol.BlockFileGN)
 _ = plain
 ```
+
+### 大型指数成分(中证2000/1000/500/A500/国证2000)
+
+`block_zs.dat` 单板块成分上限 400，装不下中证2000/1000/500 等大型指数，服务端把它们放在文本文件 `spblock.dat`（无上限），用 `GetSpBlock` 获取。
+
+> **沪深300** 例外：仍在 `block_zs.dat`，用 `GetBlockData(protocol.BlockFileZS)` 取（成分 300）。
+
+```go
+// 专业板块: 中证2000/中证1000/中证500/中证A500/国证2000/深证成指 等
+sp, _ := c.GetSpBlock()
+for _, b := range sp {
+	fmt.Printf("板块=%s 成分数=%d\n", b.Name, len(b.Codes)) // Codes 7字符: 市场(0深/1沪/2北)+代码
+}
+
+// 按名取中证2000成分
+if b := protocol.SpBlockByName(sp, "中证2000"); b != nil {
+	fmt.Printf("中证2000 成分数=%d\n", len(b.Codes)) // 2000
+}
+```
+
+> 演示: [`example/GetSpBlock`](example/GetSpBlock)。
 
 ---
 

--- a/client.go
+++ b/client.go
@@ -684,6 +684,23 @@ func (this *Client) GetXgsg() ([]*protocol.TdxXgsg, error) {
 	return protocol.ParseXgsg(data), nil
 }
 
+// GetSpBlock 下载并解析 spblock.dat(来自 zhb.zip) → 专业板块成分列表。
+//
+// spblock.dat 承载 block_zs.dat 无法容纳的大型指数成分, 如
+// 中证2000/中证1000/中证500/中证A500/国证2000/深证成指 等(block_*.dat 单板块成分上限 400)。
+// 用 protocol.SpBlockByName 按名取单个板块。注意: 沪深300 不在此文件, 在 block_zs.dat(见 GetBlockData)。
+func (this *Client) GetSpBlock() ([]*protocol.SpBlock, error) {
+	files, err := this.GetZHBFiles()
+	if err != nil {
+		return nil, err
+	}
+	data, ok := files[protocol.FileSpBlock]
+	if !ok {
+		return nil, fmt.Errorf("%s 中缺少 %s", protocol.ReportZHB, protocol.FileSpBlock)
+	}
+	return protocol.ParseSpBlock(data), nil
+}
+
 // GetTdxHy 下载并解析 tdxhy.cfg → 每只股票的通达信/申万行业归属。
 func (this *Client) GetTdxHy() ([]*protocol.TdxHy, error) {
 	buf, err := this.GetBlockFileRaw(protocol.FileTdxHy)

--- a/example/GetSpBlock/main.go
+++ b/example/GetSpBlock/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"github.com/injoyai/logs"
+	"github.com/injoyai/tdx"
+	"github.com/injoyai/tdx/protocol"
+)
+
+// 下载 spblock.dat(专业板块)并打印大型指数成分。
+//
+// spblock.dat 承载 block_zs.dat 无法容纳的成分(block_*.dat 单板块上限 400):
+// 中证2000/中证1000/中证500/中证A500/国证2000 等。
+// 沪深300 不在此文件, 在 block_zs.dat, 用 c.GetBlockData(protocol.BlockFileZS) 获取。
+func main() {
+	c, err := tdx.DialDefault()
+	logs.PanicErr(err)
+	defer c.Close()
+
+	// 1. 专业板块(中证2000/1000/500 等)
+	blocks, err := c.GetSpBlock()
+	logs.PanicErr(err)
+	logs.Infof("spblock.dat 共 %d 个专业板块\n", len(blocks))
+	for _, b := range blocks {
+		logs.Infof("板块=%s 成分数=%d\n", b.Name, len(b.Codes))
+	}
+
+	// 2. 取中证2000成分(前10)
+	if b := protocol.SpBlockByName(blocks, "中证2000"); b != nil {
+		logs.Infof("中证2000 成分数=%d, 前10=%v\n", len(b.Codes), first(b.Codes, 10))
+	}
+
+	// 3. 沪深300 走 block_zs.dat
+	zs, err := c.GetBlockData(protocol.BlockFileZS)
+	logs.PanicErr(err)
+	for _, b := range zs {
+		if b.Name == "沪深300" {
+			logs.Infof("沪深300 成分数=%d, 前10=%v\n", len(b.Codes), first(b.Codes, 10))
+		}
+	}
+}
+
+func first(s []string, n int) []string {
+	if len(s) < n {
+		return s
+	}
+	return s[:n]
+}

--- a/protocol/model_spblock.go
+++ b/protocol/model_spblock.go
@@ -1,0 +1,73 @@
+package protocol
+
+import "strings"
+
+// FileSpBlock 专业/自定义板块成分文件名(随 zhb.zip 下发)。
+//
+// 与 block_*.dat(二进制定长, 每板块成分上限 400)不同, spblock.dat 是 GBK 文本, 无成分数量上限,
+// 因此承载了 block_zs.dat 无法容纳的大型指数成分, 如 中证2000/中证1000/中证500/中证A500/国证2000 等。
+const FileSpBlock = "spblock.dat"
+
+// SpBlock 一个专业板块及其成分(来自 spblock.dat)。
+// Codes 为 7 字符, 首字符为市场标志: 0=深 1=沪 2=北; 其后 6 位为证券代码。
+// 与 Block 的 Codes 编码一致, 便于统一处理。
+type SpBlock struct {
+	Name  string   // 板块名称(已去除文件中的 '#' 前缀), 如 "中证2000"
+	Codes []string // 成分, 7 字符 "市场+代码", 如 "0000011"(深000011)
+}
+
+// ParseSpBlock 解析 spblock.dat(GBK 文本) → 专业板块列表。
+//
+// 文件格式(CRLF 分行):
+//
+//	#板块名          ← 段头, '#' 前缀 + GBK 名称
+//	0000011         ← 成分, 7 位数字 市场(1)+代码(6)
+//	0000014
+//	#下一个板块名
+//	...
+//
+// 段头行以 '#' 开头; 成分行为 7 位纯数字; 其余(空行等)忽略。
+func ParseSpBlock(data []byte) []*SpBlock {
+	lines := strings.Split(string(UTF8ToGBK(data)), "\n")
+	out := make([]*SpBlock, 0, 32)
+	var cur *SpBlock
+	for _, ln := range lines {
+		ln = strings.TrimRight(ln, "\r")
+		ln = strings.Trim(ln, "\x00")
+		if ln == "" {
+			continue
+		}
+		if strings.HasPrefix(ln, "#") {
+			cur = &SpBlock{Name: strings.TrimSpace(ln[1:])}
+			out = append(out, cur)
+			continue
+		}
+		if cur != nil && isSpCode(ln) {
+			cur.Codes = append(cur.Codes, ln)
+		}
+	}
+	return out
+}
+
+// isSpCode 判断是否为 spblock 成分行(7 位纯数字)。
+func isSpCode(s string) bool {
+	if len(s) != 7 {
+		return false
+	}
+	for i := 0; i < 7; i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// SpBlockByName 从 ParseSpBlock 结果中按名称取板块, 未命中返回 nil。
+func SpBlockByName(blocks []*SpBlock, name string) *SpBlock {
+	for _, b := range blocks {
+		if b.Name == name {
+			return b
+		}
+	}
+	return nil
+}

--- a/protocol/model_spblock_test.go
+++ b/protocol/model_spblock_test.go
@@ -1,0 +1,35 @@
+package protocol
+
+import "testing"
+
+func TestParseSpBlock(t *testing.T) {
+	// ASCII 名称: GBK 解码对 ASCII 为恒等, 便于离线构造。CRLF 分行, 混入空行/短行以验证过滤。
+	raw := []byte("#IDX2000\r\n0000011\r\n0000014\r\n1600000\r\n2920001\r\n" +
+		"\r\n#IDX500\r\n0000009\r\n123\r\nabcdefg\r\n1600519\r\n")
+
+	blocks := ParseSpBlock(raw)
+	if len(blocks) != 2 {
+		t.Fatalf("板块数 = %d, 期望 2", len(blocks))
+	}
+
+	if blocks[0].Name != "IDX2000" {
+		t.Errorf("blocks[0].Name = %q, 期望 IDX2000", blocks[0].Name)
+	}
+	if got := len(blocks[0].Codes); got != 4 {
+		t.Errorf("IDX2000 成分数 = %d, 期望 4", got)
+	}
+	if blocks[0].Codes[0] != "0000011" || blocks[0].Codes[3] != "2920001" {
+		t.Errorf("IDX2000 成分内容异常: %v", blocks[0].Codes)
+	}
+
+	// "123"(短) 与 "abcdefg"(非数字) 应被过滤, 只剩 2 条。
+	if got := len(blocks[1].Codes); got != 2 {
+		t.Errorf("IDX500 成分数 = %d, 期望 2(过滤短行/非数字行)", got)
+	}
+	if b := SpBlockByName(blocks, "IDX500"); b == nil || b.Codes[1] != "1600519" {
+		t.Errorf("SpBlockByName 结果异常: %+v", b)
+	}
+	if SpBlockByName(blocks, "不存在") != nil {
+		t.Error("SpBlockByName 未命中应返回 nil")
+	}
+}


### PR DESCRIPTION
## 背景

`block_zs.dat` 单板块成分上限 400，装不下中证2000/1000/500/A500/国证2000 等大型指数。通达信把这些成分放在 `zhb.zip` 内的文本文件 `spblock.dat`（GBK，无上限）下发，现有库未解析。

## 改动

- `protocol.ParseSpBlock` / `SpBlock` / `SpBlockByName` / `FileSpBlock`：解析 `spblock.dat`
  - 格式：GBK 文本，CRLF 分行；段头 `#名称`，成分行 7 位数字 `市场(0深/1沪/2北)+代码(6)`
- `Client.GetSpBlock()`：下载 `zhb.zip` 并解析 `spblock.dat` → 专业板块列表
- `example/GetSpBlock`：演示取中证2000成分，及沪深300（仍在 `block_zs.dat`）
- 单元测试（离线合成数据）+ README 功能表/用法

## 验证

`go build ./... && go test ./protocol/` 全过（gofmt/vet clean）。

实连通达信服务器结果：

| 板块 | 来源文件 | 成分数 |
|---|---|---|
| 中证2000 | spblock.dat | 2000 |
| 中证1000 | spblock.dat | 1000 |
| 中证500 | spblock.dat | 500 |
| 中证A500 | spblock.dat | 500 |
| 国证2000 | spblock.dat | 2000 |
| 沪深300 | block_zs.dat | 300 |

> 注：沪深300 不在 spblock.dat，仍用 `GetBlockData(protocol.BlockFileZS)`；两文件互补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)