### PR TITLE
chore: add IDE directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /dump/
 /data/
 /docs/superpowers
+.codegraph
+.vscode
+.idea


### PR DESCRIPTION
Add .codegraph, .vscode, and .idea to .gitignore to prevent IDE configuration files from being tracked.