### PR TITLE
修复可转债vol

### DIFF
--- a/client.go
+++ b/client.go
@@ -866,7 +866,7 @@ func (this *Client) GetIndex(Type uint8, code string, start, count uint16) (*pro
 	if err != nil {
 		return nil, err
 	}
-	result, err := this.SendFrame(f, protocol.KlineCache{Type: Type, Kind: protocol.KindIndex})
+	result, err := this.SendFrame(f, protocol.KlineCache{Type: Type, Kind: protocol.KindIndex, Code: code})
 	if err != nil {
 		return nil, err
 	}
@@ -970,7 +970,7 @@ func (this *Client) GetKline(Type uint8, code string, start, count uint16) (*pro
 	if err != nil {
 		return nil, err
 	}
-	result, err := this.SendFrame(f, protocol.KlineCache{Type: Type, Kind: protocol.KindStock})
+	result, err := this.SendFrame(f, protocol.KlineCache{Type: Type, Kind: protocol.KindStock, Code: code})
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/model_kline.go
+++ b/protocol/model_kline.go
@@ -187,10 +187,7 @@ func (kline) Decode(bs []byte, c KlineCache) (*KlineResp, error) {
 		*/
 		k.Volume = int64(getVolume(Uint32(bs[:4])))
 		bs = bs[4:]
-		switch c.Type {
-		case TypeKlineMinute, TypeKline5Minute, TypeKlineMinute2, TypeKline15Minute, TypeKline30Minute, TypeKline60Minute, TypeKlineDay2:
-			k.Volume /= 100
-		}
+		k.Volume = normalizeKlineVolume(k.Volume, c)
 		k.Amount = Price(getVolume(Uint32(bs[:4])) * 1000) //从元转为厘,并去除多余的小数
 		bs = bs[4:]
 
@@ -212,6 +209,17 @@ func (kline) Decode(bs []byte, c KlineCache) (*KlineResp, error) {
 type KlineCache struct {
 	Type uint8  //1分钟,5分钟,日线等
 	Kind string //指数,个股等
+	Code string //证券代码,用于区分不同品种的成交量单位
+}
+
+func normalizeKlineVolume(volume int64, c KlineCache) int64 {
+	switch c.Type {
+	case TypeKlineMinute, TypeKline5Minute, TypeKlineMinute2, TypeKline15Minute, TypeKline30Minute, TypeKline60Minute, TypeKlineDay2:
+		if !IsConvertibleBond(c.Code) {
+			return volume / 100
+		}
+	}
+	return volume
 }
 
 // FixKlineTime 修复盘内下午(13~15点)拉取数据的时候,11.30的时间变成13.00

--- a/protocol/model_kline_test.go
+++ b/protocol/model_kline_test.go
@@ -32,3 +32,24 @@ func Test_stockKline_Decode(t *testing.T) {
 		t.Log(v)
 	}
 }
+
+func TestNormalizeKlineVolume(t *testing.T) {
+	tests := []struct {
+		name   string
+		volume int64
+		cache  KlineCache
+		want   int64
+	}{
+		{name: "stock minute", volume: 43600, cache: KlineCache{Type: TypeKlineMinute, Code: "sh600000"}, want: 436},
+		{name: "sh convertible bond minute", volume: 436, cache: KlineCache{Type: TypeKlineMinute, Code: "sh110075"}, want: 436},
+		{name: "sz convertible bond minute", volume: 534, cache: KlineCache{Type: TypeKlineMinute, Code: "sz123064"}, want: 534},
+		{name: "stock day", volume: 43600, cache: KlineCache{Type: TypeKlineDay, Code: "sh600000"}, want: 43600},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := normalizeKlineVolume(test.volume, test.cache); got != test.want {
+				t.Fatalf("normalizeKlineVolume() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}

--- a/protocol/unit.go
+++ b/protocol/unit.go
@@ -164,108 +164,41 @@ func basePrice(code string) Price {
 	}
 }
 
-func getVolume(val uint32) (volume float64) {
-	ivol := int32(val)
-	logpoint := ivol >> (8 * 3)
-	//hheax := ivol >> (8 * 3)          // [3]
-	hleax := (ivol >> (8 * 2)) & 0xff // [2]
-	lheax := (ivol >> 8) & 0xff       //[1]
-	lleax := ivol & 0xff              //[0]
-
-	//dbl_1 := 1.0
-	//dbl_2 := 2.0
-	//dbl_128 := 128.0
-
-	dwEcx := logpoint*2 - 0x7f
-	dwEdx := logpoint*2 - 0x86
-	dwEsi := logpoint*2 - 0x8e
-	dwEax := logpoint*2 - 0x96
-	tmpEax := dwEcx
-	if dwEcx < 0 {
-		tmpEax = -dwEcx
-	} else {
-		tmpEax = dwEcx
-	}
-
-	dbl_xmm6 := 0.0
-	dbl_xmm6 = math.Pow(2.0, float64(tmpEax))
-	if dwEcx < 0 {
-		dbl_xmm6 = 1.0 / dbl_xmm6
-	}
-
-	dbl_xmm4 := 0.0
-	dbl_xmm0 := 0.0
-
-	if hleax > 0x80 {
-		tmpdbl_xmm3 := 0.0
-		//tmpdbl_xmm1 := 0.0
-		dwtmpeax := dwEdx + 1
-		tmpdbl_xmm3 = math.Pow(2.0, float64(dwtmpeax))
-		dbl_xmm0 = math.Pow(2.0, float64(dwEdx)) * 128.0
-		dbl_xmm0 += float64(hleax&0x7f) * tmpdbl_xmm3
-		dbl_xmm4 = dbl_xmm0
-	} else {
-		if dwEdx >= 0 {
-			dbl_xmm0 = math.Pow(2.0, float64(dwEdx)) * float64(hleax)
-		} else {
-			dbl_xmm0 = (1 / math.Pow(2.0, float64(dwEdx))) * float64(hleax)
-		}
-		dbl_xmm4 = dbl_xmm0
-	}
-
-	dbl_xmm3 := math.Pow(2.0, float64(dwEsi)) * float64(lheax)
-	dbl_xmm1 := math.Pow(2.0, float64(dwEax)) * float64(lleax)
-	if (hleax & 0x80) > 0 {
-		dbl_xmm3 *= 2.0
-		dbl_xmm1 *= 2.0
-	}
-	volume = dbl_xmm6 + dbl_xmm4 + dbl_xmm3 + dbl_xmm1
-	return
+func getVolume(val uint32) float64 {
+	return float64(math.Float32frombits(val))
 }
 
 func getVolume2(val uint32) float64 {
-	ivol := int32(val)
-	logpoint := ivol >> 24       // 提取最高字节（原8*3移位）
-	hleax := (ivol >> 16) & 0xff // 提取次高字节
-	lheax := (ivol >> 8) & 0xff  // 提取第三字节
-	lleax := ivol & 0xff         // 提取最低字节
-
-	dwEcx := logpoint*2 - 0x7f            // 基础指数计算
-	dbl_xmm6 := math.Exp2(float64(dwEcx)) // 核心指数计算仅一次
-
-	// 计算dbl_xmm4
-	var dbl_xmm4 float64
-	if hleax > 0x80 {
-		// 高位分支：合并指数计算
-		dbl_xmm4 = dbl_xmm6 * (64.0 + float64(hleax&0x7f)) / 64.0
-	} else {
-		// 低位分支：复用核心指数
-		dbl_xmm4 = dbl_xmm6 * float64(hleax) / 128.0
-	}
-
-	// 计算缩放因子
-	scale := 1.0
-	if (hleax & 0x80) != 0 {
-		scale = 2.0
-	}
-
-	// 预计算常量的倒数，优化除法
-	const (
-		inv32768   = 1.0 / 32768.0   // 2^15
-		inv8388608 = 1.0 / 8388608.0 // 2^23
-	)
-
-	// 计算低位分量
-	dbl_xmm3 := dbl_xmm6 * float64(lheax) * inv32768 * scale
-	dbl_xmm1 := dbl_xmm6 * float64(lleax) * inv8388608 * scale
-
-	// 合计最终结果
-	return dbl_xmm6 + dbl_xmm4 + dbl_xmm3 + dbl_xmm1
+	return getVolume(val)
 }
 
 // IsStock 是否是股票,示例sz000001
 func IsStock(code string) bool {
 	return IsSZStock(code) || IsSHStock(code) || IsBJStock(code)
+}
+
+// IsConvertibleBond reports whether code belongs to a current convertible-bond code range.
+func IsConvertibleBond(code string) bool {
+	if len(code) != 8 {
+		return false
+	}
+	code = strings.ToLower(code)
+	number := code[2:]
+	switch code[:2] {
+	case ExchangeSH.String():
+		return strings.HasPrefix(number, "110") ||
+			strings.HasPrefix(number, "111") ||
+			strings.HasPrefix(number, "113") ||
+			strings.HasPrefix(number, "118")
+	case ExchangeSZ.String():
+		return strings.HasPrefix(number, "123") ||
+			strings.HasPrefix(number, "125") ||
+			strings.HasPrefix(number, "126") ||
+			strings.HasPrefix(number, "127") ||
+			strings.HasPrefix(number, "128")
+	default:
+		return false
+	}
 }
 
 func IsSZStock(code string) bool {

--- a/protocol/unit_test.go
+++ b/protocol/unit_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"encoding/hex"
+	"math"
 	"testing"
 )
 
@@ -18,10 +19,29 @@ func TestUTF8ToGBK(t *testing.T) {
 	t.Log(string(bs))
 }
 
-func Test_getVolume(t *testing.T) {
-	t.Log(getVolume(1237966432))
-	t.Log(getVolume2(1237966432))
+func TestGetVolume(t *testing.T) {
+	for _, want := range []float32{0, 0.5, 1, 10, 436, 587760.1875} {
+		bits := math.Float32bits(want)
+		if got := getVolume(bits); got != float64(want) {
+			t.Errorf("getVolume(%08x) = %v, want %v", bits, got, want)
+		}
+		if got := getVolume2(bits); got != float64(want) {
+			t.Errorf("getVolume2(%08x) = %v, want %v", bits, got, want)
+		}
+	}
+}
 
+func TestIsConvertibleBond(t *testing.T) {
+	for _, code := range []string{"sh110075", "SH111000", "sh113001", "sh118001", "sz123064", "sz125001", "sz126001", "sz127001", "sz128001"} {
+		if !IsConvertibleBond(code) {
+			t.Errorf("IsConvertibleBond(%q) = false, want true", code)
+		}
+	}
+	for _, code := range []string{"sh600000", "sz000001", "sh510300", "sz159919", "sh000001", "110075"} {
+		if IsConvertibleBond(code) {
+			t.Errorf("IsConvertibleBond(%q) = true, want false", code)
+		}
+	}
 }
 
 func TestFloat32(t *testing.T) {


### PR DESCRIPTION
1. 修复成交量/成交额浮点解码
     通达信 K 线里的量额是 4 字节 float32。旧代码手工拆指数和尾数，负指数分支把符号算反，像 1 这样的低成交量会被解成约 32768。现在直接用 Go 标准库 math.Float32frombits()，小成交量不再异
     常放大；报价成交额、除权数据中复用该解码的地方也一并正确。

  2. 修复可转债分钟成交量被除以 100
     股票分钟量是“股”，需要 /100 转成“手”；可转债服务器返回的已经是“手”，旧代码仍统一 /100，导致约小 100 倍并发生整数截断。现在请求缓存会携带证券代码，识别沪市 110/111/113/118、深市
     123/125/126/127/128 可转债代码段，可转债不再执行股票的 /100。